### PR TITLE
Add Mac US/British/Canadian English keyboard shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ character of a string.
 (HORIZONTAL ELLIPSIS, U+2026) differs on various platforms.
 
  - Windows: `ALT + 0133`
- - Mac: `ALT + .`
+ - Mac: `ALT + ;` or `ALT + .`
  - Linux: `AltGr + .`
 
 ```php


### PR DESCRIPTION
The keyboard shortcut on a mac varies depending on your keyboard configurations. There are some other permutations as well. For instance, `Option + Shift + L` is the shortcut for Canadian French - CSA.
